### PR TITLE
Ensure path expansion for data sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ open_pipelines/
 # pytest-related
 .cache/
 .coverage
+.pytest_cache/
 
 # Reserved files for comparison
 *RESERVE*

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ******************************
 
+- **v0.17.2** (*2018-04-03*):
+
+  - Fixed
+
+    - Ensure data source path relativity is with respect to project config file's folder.
+
 - **v0.17.1** (*2017-12-21*):
 
   - Changed

--- a/doc/source/project-config.rst.inc
+++ b/doc/source/project-config.rst.inc
@@ -178,9 +178,10 @@ Project config complete example
 
 
 	data_sources:
-	  # specify the ABSOLUTE PATH of input files using variable path expressions
-	  # entries correspond to values in the data_source column in sample_annotation table
-	  # {variable} can be used to replace environment variables or other sample_annotation columns
+	  # Ideally, specify the ABSOLUTE PATH of input files using variable path expressions.
+	  # Alternatively, a relative path will be with respect to the project config file's folder.
+	  # Entries correspond to values in the data_source column in sample_annotation table.
+	  # {variable} can be used to replace environment variables or other sample_annotation columns.
 	  # If you use {variable} codes, you should quote the field so python can parse it.
 	  bsf_samples: "$RAWDATA/{flowcell}/{flowcell}_{lane}_samples/{flowcell}_{lane}#{BSF_name}.bam"
 	  encode_rrbs: "/path/to/shared/data/encode_rrbs_data_hg19/fastq/{sample_name}.fastq.gz"

--- a/peppy/project.py
+++ b/peppy/project.py
@@ -233,8 +233,16 @@ class Project(AttributeDict):
             _LOGGER.info("Using subproject: '{}'".format(subproject))
         self.parse_config_file(subproject)
 
-        # Ensure data_sources is at least set if it wasn't parsed.
-        self.setdefault("data_sources", None)
+        if "data_sources" in self:
+            # Expand paths now, so that it's not done for every sample.
+            for src_key, src_val in self.data_sources.items():
+                src_val = os.path.expandvars(src_val)
+                if not (os.path.isabs(src_val) or is_url(src_val)):
+                    src_val = os.path.join(os.path.dirname(self.config_file))
+                self.data_sources[src_key] = src_val
+        else:
+            # Ensure data_sources is at least set if it wasn't parsed.
+            self["data_sources"] = None
 
         self.name = self.infer_name(self.config_file)
 

--- a/peppy/project.py
+++ b/peppy/project.py
@@ -238,7 +238,7 @@ class Project(AttributeDict):
             for src_key, src_val in self.data_sources.items():
                 src_val = os.path.expandvars(src_val)
                 if not (os.path.isabs(src_val) or is_url(src_val)):
-                    src_val = os.path.join(os.path.dirname(self.config_file))
+                    src_val = os.path.join(os.path.dirname(self.config_file), src_val)
                 self.data_sources[src_key] = src_val
         else:
             # Ensure data_sources is at least set if it wasn't parsed.

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -21,7 +21,7 @@ from .const import \
     ALL_INPUTS_ATTR_NAME, DATA_SOURCE_COLNAME, DATA_SOURCES_SECTION, \
     REQUIRED_INPUTS_ATTR_NAME, SAMPLE_EXECUTION_TOGGLE, VALID_READ_TYPES
 from .utils import check_bam, check_fastq, copy, get_file_size, \
-    grab_project_data, parse_ftype, sample_folder
+    grab_project_data, is_url,parse_ftype, sample_folder
 
 COL_KEY_SUFFIX = "_key"
 
@@ -421,7 +421,8 @@ class Sample(AttributeDict):
             return ""
 
         # Populate any environment variables like $VAR with os.environ["VAR"]
-        regex = os.path.expandvars(regex)
+        # Now handled upstream, in project.
+        #regex = os.path.expandvars(regex)
 
         try:
             # Grab a temporary dictionary of sample attributes and update these


### PR DESCRIPTION
When running the `rnapipe` example, it looks like the data file paths are declared for the structure where the files are relative to the config. We need to ensure that paths are made absolute in this case, which this does, under the assumption that a relative declaration is with respect to the config file location. This also changes the timing of the env var expansion, doing it when the project parsing and creation is done rather than when sample files are located, so that we're not repeating that process unnecessarily. Not a major deal, but brings actual code into better alignment with what's going on conceptually.