### PR TITLE
use orderedDict for sample. Fix #213

### DIFF
--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -55,7 +55,8 @@ class Sample(AttributeDict):
     def __init__(self, series, prj=None):
 
         # Create data, handling library/protocol.
-        data = dict(series)
+        data = OrderedDict(series)
+        _LOGGER.debug(data)
         try:
             protocol = data.pop("library")
         except KeyError:
@@ -69,9 +70,9 @@ class Sample(AttributeDict):
         self.derived_cols_done = []
 
         if isinstance(series, Series):
-            series = series.to_dict()
+            series = series.to_dict(OrderedDict)
         elif isinstance(series, Sample):
-            series = series.as_series().to_dict()
+            series = series.as_series().to_dict(OrderedDict)
 
         # Keep a list of attributes that came from the sample sheet,
         # so we can create a minimal, ordered representation of the original.

--- a/tests/models/integration/test_Project_Sample_interaction.py
+++ b/tests/models/integration/test_Project_Sample_interaction.py
@@ -2,9 +2,7 @@
 
 from collections import OrderedDict
 import copy
-from functools import partial
 import itertools
-import logging
 import os
 import random
 
@@ -12,14 +10,10 @@ import pandas as pd
 import pytest
 import yaml
 
-import peppy
 from peppy import \
         Project, Sample, \
         SAMPLE_ANNOTATIONS_KEY, SAMPLE_NAME_COLNAME
 from peppy.utils import alpha_cased
-from tests.conftest import \
-        NGS_SAMPLE_INDICES, NUM_SAMPLES, PIPELINE_TO_REQD_INFILES_BY_SAMPLE
-from tests.helpers import named_param
 
 
 __author__ = "Vince Reuter"
@@ -110,6 +104,18 @@ def sample_sheet(samples_rawdata):
     df = pd.DataFrame(samples_rawdata)
     df.columns = [SAMPLE_NAME_COLNAME, "val1", "val2", "library"]
     return df
+
+
+
+@pytest.mark.usefixtures("write_project_files")
+class SampleSheetAttrTests:
+    """ Tests of properties of sample sheet attributes on a sample """
+
+    def test_sheet_attr_order(self, proj):
+        """ The sample's sheet attributes are ordered. """
+        s = Sample(proj.sheet.iloc[0])
+        d = s.get_sheet_dict()
+        assert SAMPLE_NAME_COLNAME == list(d)[0]
 
 
 
@@ -238,7 +244,7 @@ def project(request, tmpdir, env_config_filepath):
     anns_path = tmpdir.join(annotations_filename).strpath
     num_samples = request.getfixturevalue("num_samples")
     df = pd.DataFrame(OrderedDict(
-        [("sample_name", ["sample{}".format(i) for i in range(num_samples)]),
+        [(SAMPLE_NAME_COLNAME, ["sample{}".format(i) for i in range(num_samples)]),
          ("data", range(num_samples))]))
     with open(anns_path, 'w') as anns_file:
         df.to_csv(anns_file, sep="\t", index=False)


### PR DESCRIPTION
@vreuter 
This solves the problem for me. I can now install peppy and it fixes the downstream looper error that was making unordered stats sheets. There are 2 little things I thought might be really easy for you to help me with, that are taking me awhile, if you don't mind...

1. I have tried to add a test. I can create a simple one:
```
class SampleOrderTests:

    def test_sample_order():

	import conftest
	import peppy

        proj = conftest.interactive()
        s = peppy.Sample(proj.sheet.iloc[0])
        d = s.get_sheet_dict()
        assert list(d)[0] == 'sample_name'
```

This makes sure the `sample_name` is the first column. a simple unit test. But I cannot figure out how to insert this into the complex pytest framework.

2.  With my change, the tests succeed in python 2, but they fail in python 3 with this error: 

`TypeError: to_dict() takes 1 positional argument but 2 were given` when I try to run `pytest`.

do you know off the top of your head how to accomplish this in python 3?