### PR TITLE
add __reduce__ to Sample and Project; fix #330

### DIFF
--- a/peppy/project.py
+++ b/peppy/project.py
@@ -268,6 +268,16 @@ class Project(PathExAttMap):
             self._set_basic_samples()
             self._handle_repeat_names()
 
+    # The __reduce__ function provides an interface for
+    # correct object serialization with the pickle pickle.
+    # In this case, only the required "cfg" argument is given
+    # and kwargs used for class initialization are ignored.
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.config_file,)
+        )
+
     def _handle_repeat_names(self):
         """ Make duplicate sample names unique and save the originals """
         sample_names = [i.name for i in self.samples]

--- a/peppy/project.py
+++ b/peppy/project.py
@@ -269,7 +269,7 @@ class Project(PathExAttMap):
             self._handle_repeat_names()
 
     # The __reduce__ function provides an interface for
-    # correct object serialization with the pickle pickle.
+    # correct object serialization with the pickle module.
     # In this case, only the required "cfg" argument is given
     # and kwargs used for class initialization are ignored.
     def __reduce__(self):

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -154,7 +154,6 @@ class Sample(PathExAttMap):
             series = series.to_dict(OrderedDict)
         elif isinstance(series, Sample):
             series = series.as_series().to_dict(OrderedDict)
-        self._series = series
 
         # Keep a list of attributes that came from the sample sheet,
         # so we can create a minimal, ordered representation of the original.
@@ -186,11 +185,11 @@ class Sample(PathExAttMap):
         self.paths = Paths()
 
     # The __reduce__ function provides an interface for
-    # correct object serialization with the pickle pickle.
+    # correct object serialization with the pickle module.
     def __reduce__(self):
         return (
             self.__class__,
-            (self._series,),
+            (self.as_series(),),
             (None, {}),
             iter([]),
             iter({"prj": self.prj}.items())
@@ -244,7 +243,7 @@ class Sample(PathExAttMap):
         """
         # Note that this preserves metadata, but it could be excluded
         # with self.items() rather than self.__dict__.
-        return Series(self.__dict__)
+        return Series({k: getattr(self, k) for k in self.sheet_attributes})
 
     def check_valid(self, required=None):
         """

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -154,6 +154,7 @@ class Sample(PathExAttMap):
             series = series.to_dict(OrderedDict)
         elif isinstance(series, Sample):
             series = series.as_series().to_dict(OrderedDict)
+        self._series = series
 
         # Keep a list of attributes that came from the sample sheet,
         # so we can create a minimal, ordered representation of the original.
@@ -183,6 +184,17 @@ class Sample(PathExAttMap):
         # between times and perhaps individuals (processing time vs.
         # analysis time, and a pipeline author vs. a pipeline user).
         self.paths = Paths()
+
+    # The __reduce__ function provides an interface for
+    # correct object serialization with the pickle pickle.
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self._series,),
+            (None, {}),
+            iter([]),
+            iter({"prj": self.prj}.items())
+        )
 
     def _excl_from_eq(self, k):
         """ Exclude the Project reference from object comparison. """

--- a/tests/models/independent/test_Project.py
+++ b/tests/models/independent/test_Project.py
@@ -1,6 +1,8 @@
 """ Tests for the NGS Project model. """
 
 import copy
+import pickle
+import tempfile
 import os
 import warnings
 
@@ -721,10 +723,24 @@ class ProjectWarningTests:
         assert 0 == (len(recwarn) - num_yaml_warns)
 
 
+class ProjectSerializationTests:
+    """ Basic tests of Project serialization with pickle module. """
+
+    def test_pickle_roundtrip(self, minimal_project_conf_path):
+        """ Test whether pickle roundtrip produces a comparable object """
+        prj = Project(minimal_project_conf_path)
+
+        _buffer = tempfile.TemporaryFile()
+        pickle.dump(prj, _buffer)
+        _buffer.seek(0)
+        new_prj = pickle.load(_buffer)
+        assert prj == new_prj
+
+
 def _write_project_config(config_data, dirpath, filename="proj-conf.yaml"):
     """
     Write the configuration file for a Project.
-    
+
     :param dict config_data: configuration data to write to disk
     :param str dirpath: path to folder in which to place file
     :param str filename: name for config file

--- a/tests/models/independent/test_Sample.py
+++ b/tests/models/independent/test_Sample.py
@@ -492,12 +492,9 @@ class SampleConstructorTests:
 class SampleSerializationTests:
     """ Basic tests of Sample serialization with pickle module. """
 
-    @pytest.mark.parametrize("name_attr", [SAMPLE_NAME_COLNAME, "name"])
-    def test_pickle_roundtrip(self, name_attr):
+    def test_pickle_roundtrip(self):
         """ Test whether pickle roundtrip produces a comparable object """
-        name = "testsample"
-        s = Sample({SAMPLE_NAME_COLNAME: name})
-
+        s = Sample({SAMPLE_NAME_COLNAME: "testsample"})
         _buffer = tempfile.TemporaryFile()
         pickle.dump(s, _buffer)
         _buffer.seek(0)

--- a/tests/models/independent/test_Sample.py
+++ b/tests/models/independent/test_Sample.py
@@ -2,7 +2,10 @@
 
 from collections import Mapping
 import copy
+import pickle
+import tempfile
 import os
+
 
 import mock
 import numpy as np
@@ -484,6 +487,22 @@ class SampleConstructorTests:
         assert {} == diff
         extra = [v for k, v in obs_meta.items() if k not in exp_meta]
         assert not any(extra)
+
+
+class SampleSerializationTests:
+    """ Basic tests of Sample serialization with pickle module. """
+
+    @pytest.mark.parametrize("name_attr", [SAMPLE_NAME_COLNAME, "name"])
+    def test_pickle_roundtrip(self, name_attr):
+        """ Test whether pickle roundtrip produces a comparable object """
+        name = "testsample"
+        s = Sample({SAMPLE_NAME_COLNAME: name})
+
+        _buffer = tempfile.TemporaryFile()
+        pickle.dump(s, _buffer)
+        _buffer.seek(0)
+        new_s = pickle.load(_buffer)
+        assert s == new_s
 
 
 def _get_prj(conf_file, data, proj_type):


### PR DESCRIPTION
This should restore the ability to pickle/unpickle Sample and Project objects.