### PR TITLE
Adjust peppy to handle different read types for the same sample

### DIFF
--- a/peppy/project.py
+++ b/peppy/project.py
@@ -296,11 +296,11 @@ class Project(PathExAttMap):
             p_dict["_samples"] = [s.to_dict() for s in self.samples]
         return p_dict
 
-    def create_samples(self, modify=False):
+    def create_samples(self, modify: bool = False):
         """
         Populate Project with Sample objects
         """
-        self._samples = self.load_samples()
+        self._samples: List[Sample] = self.load_samples()
         if modify:
             self.modify_samples()
         else:
@@ -594,56 +594,42 @@ class Project(PathExAttMap):
             specified in the config
         """
         sample_names_list = [getattr(s, self.st_index) for s in self.samples]
-        dups_set = set(
-            [
-                x
-                for x in track(
-                    sample_names_list,
-                    description="Detecting duplicate sample names",
-                    disable=not self.is_sample_table_large,
-                )
-                if sample_names_list.count(x) > 1
-            ]
-        )
-        if not dups_set:
-            # all sample names are unique
+        duplicated_sample_ids = self._get_duplicated_sample_ids(sample_names_list)
+
+        if not duplicated_sample_ids:
             return
+
         _LOGGER.info(
-            f"Found {len(dups_set)} samples with non-unique names: {dups_set}. Attempting to auto-merge."
+            f"Found {len(duplicated_sample_ids)} samples with non-unique names: {duplicated_sample_ids}. Attempting to auto-merge."
         )
         if SUBSAMPLE_DF_KEY in self and self[SUBSAMPLE_DF_KEY] is not None:
             raise IllegalStateException(
                 f"Duplicated sample names found and subsample_table is specified in the config; "
                 f"you may use either auto-merging or subsample_table-based merging. "
-                f"Duplicates: {dups_set}"
+                f"Duplicates: {duplicated_sample_ids}"
             )
-        for duplication in dups_set:
+
+        for duplicated_id in duplicated_sample_ids:
             (
                 duplicated_samples,
                 non_duplicated_samples,
             ) = self._get_duplicated_and_not_duplicated_samples(
-                duplication, self.st_index, self.samples
+                duplicated_id, self.st_index, self.samples
             )
-            self._samples = non_duplicated_samples
-
-            sample_attrs = [
+            sample_attributes = [
                 attr
                 for attr in duplicated_samples[0].keys()
                 if not attr.startswith("_")
             ]
-
-            merged_attrs = {}
-            for attr in sample_attrs:
-                merged_attrs[attr] = list(
-                    flatten([getattr(s, attr) for s in duplicated_samples])
-                )
+            merged_attrs = self._get_merged_attributes(
+                sample_attributes, duplicated_samples
+            )
+            self._samples = non_duplicated_samples
 
             # make single element lists scalars
-            for attribute, values in merged_attrs.items():
-                if isinstance(
-                    values, list
-                ) and self._all_values_in_the_list_are_the_same(values):
-                    merged_attrs[attribute] = values[0]
+            for attribute_name, values in merged_attrs.items():
+                if isinstance(values, list) and len(list(set(values))) == 1:
+                    merged_attrs[attribute_name] = values[0]
 
             self.add_samples(Sample(series=merged_attrs))
 
@@ -673,6 +659,43 @@ class Project(PathExAttMap):
     @staticmethod
     def _all_values_in_the_list_are_the_same(list_of_values: List) -> bool:
         return all(value == list_of_values[0] for value in list_of_values)
+
+    @staticmethod
+    def _get_duplicated_sample_ids(sample_names_list: List) -> set:
+        return set(
+            [
+                sample_id
+                for sample_id in track(
+                    sample_names_list,
+                    description="Detecting duplicate sample names",
+                    disable=not Project.is_sample_table_large,
+                )
+                if sample_names_list.count(sample_id) > 1
+            ]
+        )
+
+    @staticmethod
+    def _get_merged_attributes(
+        sample_attributes: List[str], duplicated_samples: List[Sample]
+    ) -> dict:
+        merged_attributes = {}
+        for attr in sample_attributes:
+
+            attribute_values = []
+            for sample in duplicated_samples:
+                attribute_value_for_sample = Project.safe_getattr(sample, attr)
+                attribute_values.append(attribute_value_for_sample)
+
+            merged_attributes[attr] = list(flatten(attribute_values))
+
+        return merged_attributes
+
+    @staticmethod
+    def safe_getattr(object: object, attribute: str):
+        try:
+            return getattr(object, attribute)
+        except AttributeError:
+            return ""
 
     def attr_merge(self):
         """
@@ -1221,6 +1244,27 @@ class Project(PathExAttMap):
         :param str sample_table: a path to a sample table
         :param List[str] sample_table: a list of paths to sample tables
         """
+
+        def _read_tab(pth):
+            """
+            Internal read table function
+
+            :param str pth: absolute path to the file to read
+            :return pandas.DataFrame: table object
+            """
+            csv_kwargs = {
+                "dtype": str,
+                "index_col": False,
+                "keep_default_na": False,
+                "na_values": [""],
+            }
+            try:
+                return pd.read_csv(pth, sep=infer_delimiter(pth), **csv_kwargs)
+            except Exception as e:
+                raise SampleTableFileException(
+                    f"Could not read table: {pth}. "
+                    f"Caught exception: {getattr(e, 'message', repr(e))}"
+                )
 
         no_metadata_msg = "No {} specified"
         if self[SAMPLE_TABLE_FILE_KEY] is not None:

--- a/tests/data/example_peps-master/example_nextflow_samplesheet/samplesheet.csv
+++ b/tests/data/example_peps-master/example_nextflow_samplesheet/samplesheet.csv
@@ -1,0 +1,6 @@
+sample,run_accession,instrument_platform,fastq_1,fastq_2,fasta
+2611,ERR5766174,ILLUMINA,,,/<path>/<to>/fasta/ERX5474930_ERR5766174_1.fa.gz
+2612,ERR5766176,ILLUMINA,/<path>/<to>/fastq/ERX5474932_ERR5766176_1.fastq.gz,/<path>/<to>/fastq/ERX5474932_ERR5766176_2.fastq.gz,
+2612,ERR5766180,ILLUMINA,/<path>/<to>/fastq/ERX5474936_ERR5766180_1.fastq.gz,,
+2613,ERR5766181,ILLUMINA,/<path>/<to>/fastq/ERX5474937_ERR5766181_1.fastq.gz,/<path>/<to>/fastq/ERX5474937_ERR5766181_2.fastq.gz,
+ERR3201952,ERR3201952,OXFORD_NANOPORE,/<path>/<to>/fastq/ERR3201952.fastq.gz,,

--- a/tests/smoketests/conftest.py
+++ b/tests/smoketests/conftest.py
@@ -61,3 +61,8 @@ def example_peps_cfg_paths(request):
         )
         for p in request.param
     ]
+
+
+@pytest.fixture
+def nextflow_sample_table_path():
+    return "tests/data/example_peps-master/example_nextflow_samplesheet/samplesheet.csv"

--- a/tests/smoketests/test_Project.py
+++ b/tests/smoketests/test_Project.py
@@ -70,7 +70,7 @@ def _cmp_all_samples_attr(p1, p2, attr):
     ]
 
 
-class ProjectConstructorTests:
+class TestProjectConstructor:
     def test_empty(self):
         """Verify that an empty Project instance can be created"""
         p = Project()
@@ -355,8 +355,14 @@ class ProjectConstructorTests:
         p = Project(cfg=example_pep_csv_path)
         assert isinstance(p.pep_version, str)
 
+    def test_auto_merge_duplicated_names_works_for_different_read_types(
+        self, nextflow_sample_table_path
+    ):
+        p = Project(nextflow_sample_table_path, sample_table_index="sample")
+        assert len(p.samples) == 4
 
-class ProjectManipulationTests:
+
+class TestProjectManipulationTests:
     @pytest.mark.parametrize("example_pep_cfg_path", ["amendments1"], indirect=True)
     def test_amendments_activation_interactive(self, example_pep_cfg_path):
         """
@@ -456,7 +462,7 @@ class ProjectManipulationTests:
             p.get_sample(sample_name="kdkdkdk")
 
 
-class SampleModifiersTests:
+class TestSampleModifiers:
     @pytest.mark.parametrize("example_pep_cfg_path", ["append"], indirect=True)
     def test_append(self, example_pep_cfg_path):
         """Verify that the appended attribute is added to the samples"""
@@ -522,7 +528,7 @@ class SampleModifiersTests:
         )
 
 
-class PostInitSampleCreationTests:
+class TestPostInitSampleCreation:
     @pytest.mark.parametrize("example_pep_cfg_path", ["append"], indirect=True)
     def test_append(self, example_pep_cfg_path):
         """


### PR DESCRIPTION
- Add handler for `AttributeError` raised by `getattr()` and return empty string if there is no value for given attribute
- Add test