### PR TITLE
peppy typehints docstrings

### DIFF
--- a/peppy/exceptions.py
+++ b/peppy/exceptions.py
@@ -2,6 +2,7 @@
 
 from abc import ABCMeta
 from collections.abc import Iterable
+from typing import Optional
 
 __all__ = [
     "IllegalStateException",
@@ -19,7 +20,7 @@ class PeppyError(Exception):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         super(PeppyError, self).__init__(msg)
 
 
@@ -50,7 +51,7 @@ class RemoteYAMLError(PeppyError):
 class MissingAmendmentError(PeppyError):
     """Error when project config lacks a requested subproject."""
 
-    def __init__(self, amendment, defined=None):
+    def __init__(self, amendment: str, defined: Optional[Iterable[str]] = None) -> None:
         """
         Create exception with missing amendment request.
 

--- a/peppy/exceptions.py
+++ b/peppy/exceptions.py
@@ -52,11 +52,11 @@ class MissingAmendmentError(PeppyError):
     """Error when project config lacks a requested subproject."""
 
     def __init__(self, amendment: str, defined: Optional[Iterable[str]] = None) -> None:
-        """
-        Create exception with missing amendment request.
+        """Create exception with missing amendment request.
 
-        :param str amendment: the requested (and missing) amendment
-        :param Iterable[str] defined: collection of names of defined amendment
+        Args:
+            amendment: The requested (and missing) amendment
+            defined: Collection of names of defined amendments
         """
         msg = "Amendment '{}' not found".format(amendment)
         if isinstance(defined, Iterable):

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from copy import copy as cp
 from logging import getLogger
 from string import Formatter
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import pandas as pd
 import yaml
@@ -39,7 +39,7 @@ class Sample(SimpleAttMap):
     :param Mapping | pandas.core.series.Series series: Sample's data.
     """
 
-    def __init__(self, series, prj=None):
+    def __init__(self, series: Union[Mapping, Series], prj: Optional[Any] = None) -> None:
         super(Sample, self).__init__()
 
         data = dict(series)
@@ -75,7 +75,7 @@ class Sample(SimpleAttMap):
         self._derived_cols_done = []
         self._attributes = list(series.keys())
 
-    def get_sheet_dict(self):
+    def get_sheet_dict(self) -> Dict:
         """
         Create a K-V pairs for items originally passed in via the sample sheet.
         This is useful for summarizing; it provides a representation of the
@@ -87,7 +87,7 @@ class Sample(SimpleAttMap):
         """
         return dict([[k, self[k]] for k in self._attributes])
 
-    def to_dict(self, add_prj_ref=False):
+    def to_dict(self, add_prj_ref: bool = False) -> Dict:
         """
         Serializes itself as dict object.
 

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -76,24 +76,27 @@ class Sample(SimpleAttMap):
         self._attributes = list(series.keys())
 
     def get_sheet_dict(self) -> Dict:
-        """
-        Create a K-V pairs for items originally passed in via the sample sheet.
+        """Create K-V pairs for items originally passed in via the sample sheet.
+
         This is useful for summarizing; it provides a representation of the
         sample that excludes things like config files and derived entries.
 
-        :return OrderedDict: mapping from name to value for data elements
-            originally provided via the sample sheet (i.e., the a map-like
-            representation of the instance, excluding derived items)
+        Returns:
+            Mapping from name to value for data elements originally provided
+            via the sample sheet (i.e., a map-like representation of the
+            instance, excluding derived items)
         """
         return dict([[k, self[k]] for k in self._attributes])
 
     def to_dict(self, add_prj_ref: bool = False) -> Dict:
-        """
-        Serializes itself as dict object.
+        """Serializes itself as dict object.
 
-        :param bool add_prj_ref: whether the project reference bound do the
-            Sample object should be included in the YAML representation
-        :return dict: dict representation of this Sample
+        Args:
+            add_prj_ref: Whether the project reference bound to the Sample
+                object should be included in the dict representation
+
+        Returns:
+            Dict representation of this Sample
         """
 
         def _obj2dict(obj, name=None):
@@ -136,16 +139,19 @@ class Sample(SimpleAttMap):
         return serial
 
     def to_yaml(
-        self, path: Optional[str] = None, add_prj_ref=False
+        self, path: Optional[str] = None, add_prj_ref: bool = False
     ) -> Union[str, None]:
-        """
-        Serializes itself in YAML format. Writes to file if path is provided, else returns string representation.
+        """Serializes itself in YAML format.
 
-        :param str path: A file path to write yaml to; provide this or
-            the subs_folder_path, defaults to None
-        :param bool add_prj_ref: whether the project reference bound do the
-            Sample object should be included in the YAML representation
-        :return str | None: returns string representation of sample yaml or None
+        Writes to file if path is provided, else returns string representation.
+
+        Args:
+            path: A file path to write YAML to; defaults to None
+            add_prj_ref: Whether the project reference bound to the Sample
+                object should be included in the YAML representation
+
+        Returns:
+            String representation of sample YAML or None if written to file
         """
         serial = self.to_dict(add_prj_ref=add_prj_ref)
         if path:

--- a/peppy/sample.py
+++ b/peppy/sample.py
@@ -39,7 +39,9 @@ class Sample(SimpleAttMap):
     :param Mapping | pandas.core.series.Series series: Sample's data.
     """
 
-    def __init__(self, series: Union[Mapping, Series], prj: Optional[Any] = None) -> None:
+    def __init__(
+        self, series: Union[Mapping, Series], prj: Optional[Any] = None
+    ) -> None:
         super(Sample, self).__init__()
 
         data = dict(series)

--- a/peppy/utils.py
+++ b/peppy/utils.py
@@ -30,7 +30,9 @@ def copy(obj: Any) -> Any:
     return obj
 
 
-def make_abs_via_cfg(maybe_relpath: str, cfg_path: str, check_exists: bool = False) -> str:
+def make_abs_via_cfg(
+    maybe_relpath: str, cfg_path: str, check_exists: bool = False
+) -> str:
     """Ensure that a possibly relative path is absolute.
 
     Args:
@@ -186,7 +188,9 @@ def load_yaml(filepath: str) -> dict:
         return expand_paths(data)
 
 
-def is_cfg_or_anno(file_path: Optional[str], formats: Optional[dict] = None) -> Optional[bool]:
+def is_cfg_or_anno(
+    file_path: Optional[str], formats: Optional[dict] = None
+) -> Optional[bool]:
     """Determine if the input file seems to be a project config file (based on extension).
 
     Args:

--- a/peppy/utils.py
+++ b/peppy/utils.py
@@ -31,7 +31,20 @@ def copy(obj: Any) -> Any:
 
 
 def make_abs_via_cfg(maybe_relpath: str, cfg_path: str, check_exists: bool = False) -> str:
-    """Ensure that a possibly relative path is absolute."""
+    """Ensure that a possibly relative path is absolute.
+
+    Args:
+        maybe_relpath: Path that may be relative
+        cfg_path: Path to configuration file
+        check_exists: Whether to verify the resulting path exists
+
+    Returns:
+        Absolute path
+
+    Raises:
+        TypeError: If maybe_relpath is not a string
+        OSError: If check_exists is True and path doesn't exist
+    """
     if not isinstance(maybe_relpath, str):
         raise TypeError(
             "Attempting to ensure non-text value is absolute path: {} ({})".format(
@@ -57,18 +70,23 @@ def make_abs_via_cfg(maybe_relpath: str, cfg_path: str, check_exists: bool = Fal
 
 
 def grab_project_data(prj: Any) -> Mapping:
-    """
-    From the given Project, grab Sample-independent data.
+    """From the given Project, grab Sample-independent data.
 
     There are some aspects of a Project of which it's beneficial for a Sample
     to be aware, particularly for post-hoc analysis. Since Sample objects
     within a Project are mutually independent, though, each doesn't need to
-    know about any of the others. A Project manages its, Sample instances,
+    know about any of the others. A Project manages its Sample instances,
     so for each Sample knowledge of Project data is limited. This method
     facilitates adoption of that conceptual model.
 
-    :param Project prj: Project from which to grab data
-    :return Mapping: Sample-independent data sections from given Project
+    Args:
+        prj: Project from which to grab data
+
+    Returns:
+        Sample-independent data sections from given Project
+
+    Raises:
+        KeyError: If project lacks required config section
     """
     if not prj:
         return {}
@@ -80,16 +98,17 @@ def grab_project_data(prj: Any) -> Mapping:
 
 
 def make_list(arg: Union[list, str], obj_class: Type) -> list:
-    """
-    Convert an object of predefined class to a list of objects of that class or
-    ensure a list is a list of objects of that class
+    """Convert an object of predefined class to a list or ensure list contains correct type.
 
-    :param list[obj] | obj arg: string or a list of strings to listify
-    :param str obj_class: name of the class of intrest
+    Args:
+        arg: Object or list of objects to listify
+        obj_class: Class that objects should be instances of
 
-    :return list: list of objects of the predefined class
+    Returns:
+        List of objects of the predefined class
 
-    :raise TypeError: if a faulty argument was provided
+    Raises:
+        TypeError: If a faulty argument was provided
     """
 
     def _raise_faulty_arg():
@@ -109,22 +128,26 @@ def make_list(arg: Union[list, str], obj_class: Type) -> list:
         _raise_faulty_arg()
 
 
-def _expandpath(path: str):
-    """
-    Expand a filesystem path that may or may not contain user/env vars.
+def _expandpath(path: str) -> str:
+    """Expand a filesystem path that may or may not contain user/env vars.
 
-    :param str path: path to expand
-    :return str: expanded version of input path
+    Args:
+        path: Path to expand
+
+    Returns:
+        Expanded version of input path
     """
     return os.path.expandvars(os.path.expanduser(path))
 
 
 def expand_paths(x: dict) -> dict:
-    """
-    Recursively expand paths in a dict.
+    """Recursively expand paths in a dict.
 
-    :param dict x: dict to expand
-    :return dict: dict with expanded paths
+    Args:
+        x: Dict to expand
+
+    Returns:
+        Dict with expanded paths
     """
     if isinstance(x, str):
         return expandpath(x)
@@ -134,12 +157,16 @@ def expand_paths(x: dict) -> dict:
 
 
 def load_yaml(filepath: str) -> dict:
-    """
-    Load a local or remote YAML file into a Python dict
+    """Load a local or remote YAML file into a Python dict.
 
-    :param str filepath: path to the file to read
-    :raises RemoteYAMLError: if the remote YAML file reading fails
-    :return dict: read data
+    Args:
+        filepath: Path to the file to read
+
+    Returns:
+        Read data
+
+    Raises:
+        RemoteYAMLError: If the remote YAML file reading fails
     """
     if is_url(filepath):
         _LOGGER.debug(f"Got URL: {filepath}")
@@ -160,12 +187,18 @@ def load_yaml(filepath: str) -> dict:
 
 
 def is_cfg_or_anno(file_path: Optional[str], formats: Optional[dict] = None) -> Optional[bool]:
-    """
-    Determine if the input file seems to be a project config file (based on the file extension).
-    :param str file_path: file path to examine
-    :param dict formats: formats dict to use. Must include 'config' and 'annotation' keys.
-    :raise ValueError: if the file seems to be neither a config nor an annotation
-    :return bool: True if the file is a config, False if the file is an annotation
+    """Determine if the input file seems to be a project config file (based on extension).
+
+    Args:
+        file_path: File path to examine
+        formats: Formats dict to use. Must include 'config' and 'annotation' keys
+
+    Returns:
+        True if the file is a config, False if the file is an annotation,
+        None if file_path is None
+
+    Raises:
+        ValueError: If the file seems to be neither a config nor an annotation
     """
     formats_dict = formats or {
         "config": (".yaml", ".yml"),
@@ -186,7 +219,14 @@ def is_cfg_or_anno(file_path: Optional[str], formats: Optional[dict] = None) -> 
 
 
 def extract_custom_index_for_sample_table(pep_dictionary: Dict) -> Optional[str]:
-    """Extracts a custom index for the sample table if it exists"""
+    """Extracts a custom index for the sample table if it exists.
+
+    Args:
+        pep_dictionary: PEP configuration dictionary
+
+    Returns:
+        Custom index name or None if not specified
+    """
     return (
         pep_dictionary[SAMPLE_TABLE_INDEX_KEY]
         if SAMPLE_TABLE_INDEX_KEY in pep_dictionary
@@ -195,7 +235,14 @@ def extract_custom_index_for_sample_table(pep_dictionary: Dict) -> Optional[str]
 
 
 def extract_custom_index_for_subsample_table(pep_dictionary: Dict) -> Optional[str]:
-    """Extracts a custom index for the subsample table if it exists"""
+    """Extracts a custom index for the subsample table if it exists.
+
+    Args:
+        pep_dictionary: PEP configuration dictionary
+
+    Returns:
+        Custom index name or None if not specified
+    """
     return (
         pep_dictionary[SUBSAMPLE_TABLE_INDEX_KEY]
         if SUBSAMPLE_TABLE_INDEX_KEY in pep_dictionary
@@ -204,10 +251,14 @@ def extract_custom_index_for_subsample_table(pep_dictionary: Dict) -> Optional[s
 
 
 def unpopulated_env_var(paths: Set[str]) -> None:
-    """
+    """Print warnings for unpopulated environment variables in paths.
+
     Given a set of paths that may contain env vars, group by env var and
     print a warning for each group with the deepest common directory and
     the paths relative to that directory.
+
+    Args:
+        paths: Set of paths that may contain environment variables
     """
     _VAR_RE = re.compile(r"^\$(\w+)/(.*)$")
     groups: dict[str, list[str]] = defaultdict(list)

--- a/peppy/utils.py
+++ b/peppy/utils.py
@@ -5,7 +5,7 @@ import os
 import posixpath as psp
 import re
 from collections import defaultdict
-from typing import Dict, Mapping, Set, Type, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Set, Type, Union
 from urllib.request import urlopen
 
 import yaml
@@ -17,7 +17,7 @@ from .exceptions import RemoteYAMLError
 _LOGGER = logging.getLogger(__name__)
 
 
-def copy(obj):
+def copy(obj: Any) -> Any:
     def copy(self):
         """
         Copy self to a new object.
@@ -30,7 +30,7 @@ def copy(obj):
     return obj
 
 
-def make_abs_via_cfg(maybe_relpath, cfg_path, check_exists=False):
+def make_abs_via_cfg(maybe_relpath: str, cfg_path: str, check_exists: bool = False) -> str:
     """Ensure that a possibly relative path is absolute."""
     if not isinstance(maybe_relpath, str):
         raise TypeError(
@@ -56,7 +56,7 @@ def make_abs_via_cfg(maybe_relpath, cfg_path, check_exists=False):
     return abs_path
 
 
-def grab_project_data(prj):
+def grab_project_data(prj: Any) -> Mapping:
     """
     From the given Project, grab Sample-independent data.
 
@@ -133,7 +133,7 @@ def expand_paths(x: dict) -> dict:
     return x
 
 
-def load_yaml(filepath):
+def load_yaml(filepath: str) -> dict:
     """
     Load a local or remote YAML file into a Python dict
 
@@ -159,7 +159,7 @@ def load_yaml(filepath):
         return expand_paths(data)
 
 
-def is_cfg_or_anno(file_path, formats=None):
+def is_cfg_or_anno(file_path: Optional[str], formats: Optional[dict] = None) -> Optional[bool]:
     """
     Determine if the input file seems to be a project config file (based on the file extension).
     :param str file_path: file path to examine
@@ -185,7 +185,7 @@ def is_cfg_or_anno(file_path, formats=None):
     )
 
 
-def extract_custom_index_for_sample_table(pep_dictionary: Dict):
+def extract_custom_index_for_sample_table(pep_dictionary: Dict) -> Optional[str]:
     """Extracts a custom index for the sample table if it exists"""
     return (
         pep_dictionary[SAMPLE_TABLE_INDEX_KEY]
@@ -194,7 +194,7 @@ def extract_custom_index_for_sample_table(pep_dictionary: Dict):
     )
 
 
-def extract_custom_index_for_subsample_table(pep_dictionary: Dict):
+def extract_custom_index_for_subsample_table(pep_dictionary: Dict) -> Optional[str]:
     """Extracts a custom index for the subsample table if it exists"""
     return (
         pep_dictionary[SUBSAMPLE_TABLE_INDEX_KEY]
@@ -203,7 +203,7 @@ def extract_custom_index_for_subsample_table(pep_dictionary: Dict):
     )
 
 
-def unpopulated_env_var(paths: Set[str]):
+def unpopulated_env_var(paths: Set[str]) -> None:
     """
     Given a set of paths that may contain env vars, group by env var and
     print a warning for each group with the deepest common directory and

--- a/peppy/utils.py
+++ b/peppy/utils.py
@@ -5,7 +5,7 @@ import os
 import posixpath as psp
 import re
 from collections import defaultdict
-from typing import Any, Callable, Dict, Mapping, Optional, Set, Type, Union
+from typing import Any, Dict, Mapping, Optional, Set, Type, Union
 from urllib.request import urlopen
 
 import yaml


### PR DESCRIPTION
This PR Stacks on #503 

It adds typehints, and reformats docstrings to google-style, for the main peppy modules.


. Added Type Hints (Commit: 8acceb7)
Added clear and explicit type hints to the main peppy modules:

utils.py: All 10 functions now have complete type hints (parameters and return types)
exceptions.py: Exception __init__ methods have proper type hints with Optional types
sample.py: Sample class methods including __init__, get_sheet_dict, to_dict, and to_yaml
2. Converted Docstrings to Google-Style (Commit: 01cf21d)
Converted 14 docstrings from reStructuredText to Google-style format:

utils.py: 10 functions
exceptions.py: 1 function
sample.py: 3 methods
3. Applied Black Formatting (Commit: 3fcbf21)
Ran black formatter on all modified files to ensure consistent code style.

