### PR TITLE
Port eido pandas 3.0 fix into vendored eido

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         os: [ubuntu-latest]
 
     steps:

--- a/example_peps-cfg2/README.md
+++ b/example_peps-cfg2/README.md
@@ -9,6 +9,7 @@ Your basic python workflow uses the [peppy](http://github.com/pepkit/peppy) pack
 
 ```{python}
 import peppy
+
 proj1 = peppy.Project("example_basic/project_config.yaml")
 ```
 More detailed Python vignettes are available as part of the [documentation for the peppy package](https://peppy.readthedocs.io/en/latest/index.html).

--- a/peppy/eido/output_formatters.py
+++ b/peppy/eido/output_formatters.py
@@ -110,6 +110,11 @@ class MultilineOutputFormatter(BaseOutputFormatter):
             else:
                 value = sample.get(attribute)
 
+            if isinstance(value, float) and value != value:
+                # pandas (>=3.0) yields float('nan') instead of None for missing
+                # values when a Sample's attributes originate from a DataFrame
+                value = None
+
             sample_row.append(value or "")
 
         return ",".join(sample_row)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "pandas>=2.2.0,<3.0.0",
+    "pandas>=2.2.0",
     "pyyaml>=6.0.0",
     "rich>=10.3.0",
     "ubiquerg>=0.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "peppy"
-version = "0.50.0a2"
+version = "0.50.0"
 description = "A python-based project metadata manager for portable encapsulated projects"
 readme = "README.md"
 license = "BSD-2-Clause"
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["project", "metadata", "bioinformatics", "sequencing", "ngs", "workflow"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "python-dotenv",
     "coverage",
     "smokeshow",
+    "ruff",
 ]
 
 [build-system]

--- a/tests/data/peppydata/example_peps-master/README.md
+++ b/tests/data/peppydata/example_peps-master/README.md
@@ -45,6 +45,7 @@ Your basic python workflow uses the [`peppy`](http://github.com/pepkit/peppy) pa
 
 ```python
 import peppy
+
 proj1 = peppy.Project("example_basic/project_config.yaml")
 ```
 More detailed Python vignettes are available as part of the [documentation for the `peppy` package](http://peppy.databio.org/en/latest/).

--- a/tests/eidotests/test_conversions.py
+++ b/tests/eidotests/test_conversions.py
@@ -4,7 +4,9 @@ from peppy.eido.conversion import (
     pep_conversion_plugins,
     run_filter,
 )
+from peppy.eido.output_formatters import MultilineOutputFormatter
 from peppy.project import Project
+from peppy.sample import Sample
 
 
 class TestConversionInfrastructure:
@@ -104,3 +106,30 @@ class TestConversionInfrastructure:
             "yaml-samples",
         )
         assert isinstance(conversion["samples"], str)
+
+
+class TestMultilineOutputFormatterMissingValues:
+    """
+    Under pandas >=3.0 a missing attribute reaches the formatter as float('nan')
+    rather than as an empty string, which used to raise TypeError from the join.
+    """
+
+    def test_missing_attribute_becomes_empty_field(self):
+        sample = Sample({"sample": "frog_1", "fasta": float("nan")})
+
+        assert MultilineOutputFormatter.format([sample]) == "sample,fasta\nfrog_1,\n"
+
+    def test_missing_subsample_attribute_becomes_empty_field(self):
+        # Merging a subsample table that lacks a column produces a list of nan
+        sample = Sample(
+            {
+                "sample": "frog_1",
+                "fasta": [float("nan"), float("nan")],
+                "subsample_name": ["0", "1"],
+            }
+        )
+
+        assert (
+            MultilineOutputFormatter.format([sample])
+            == "sample,fasta\nfrog_1,\nfrog_1,\n"
+        )


### PR DESCRIPTION
Ports the pandas 3.0 fix from eido into peppy's vendored `peppy/eido/`.

- Relaxes the pandas `<3.0` upper bound in `pyproject.toml`.
- Converts `float('nan')` -> `None` in the multiline output formatter, so missing values from pandas >=3.0 DataFrames render as empty fields instead of raising.
- Adds regression tests for the missing-attribute and missing-subsample cases.

The change mirrors the upstream eido fix (byte-identical formatter patch).

Upstream references:
- pepkit/eido#84 (issue: Support pandas 3.0)
- pepkit/eido#83 (merged fix: Release pandas upper bound; fix float nan/None issue)